### PR TITLE
Port genicons.py to Python3 from Python2

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ located at [`scripts/genicons.py`](scripts/genicons.py).
 2. Install Python 3 and required Python 3 packages:
 
     ```shell
-    sudo apt-get install python3 python3-gi-cairo
+    sudo apt-get install gir1.2-pango-1.0 python3-gi-cairo
     ```
 
 3. Install CC Icons font
@@ -36,7 +36,7 @@ located at [`scripts/genicons.py`](scripts/genicons.py).
 Execute with Python 3:
 
 ```shell
-python3 genicons.py
+python3 scripts/genicons.py
 ```
 
 This will generate the icons in the directory `www/i` directory.

--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@ located at [`scripts/genicons.py`](scripts/genicons.py).
 ### Install
 
 1. Assuming the repository is on Debian
-2. Install required Python 2 packages:
+2. Install Python 3 and required Python 3 packages:
 
     ```shell
-    sudo apt-get install python-cairo python-gtk2
+    sudo apt-get install python3 python3-gi-cairo
     ```
 
 3. Install CC Icons font
@@ -33,10 +33,10 @@ located at [`scripts/genicons.py`](scripts/genicons.py).
 
 ### Usage
 
-Execute with Python 2:
+Execute with Python 3:
 
 ```shell
-python genicons.py
+python3 genicons.py
 ```
 
 This will generate the icons in the directory `www/i` directory.

--- a/scripts/genicons.py
+++ b/scripts/genicons.py
@@ -9,7 +9,10 @@ import os.path
 
 # Third-party
 import cairo
-import pangocairo
+import gi
+gi.require_version('PangoCairo', '1.0')
+from gi.repository import PangoCairo as pangocairo
+from functools import reduce
 
 
 SUITES = {
@@ -80,8 +83,8 @@ def show_chars(ctx, chars, foreground, padding, width, height):
 def create_context(width, height):
     surface = cairo.ImageSurface(cairo.FORMAT_ARGB32, width, height)
     context = cairo.Context(surface)
-    ctx = pangocairo.CairoContext(context)
-    return ctx
+    # ctx = pangocairo.CairoContext(context)
+    return context
 
 
 def set_background(ctx, background, width, height):
@@ -128,7 +131,7 @@ def genicon(
     return ctx
 
 
-font_map = pangocairo.cairo_font_map_get_default()
+font_map = pangocairo.font_map_get_default()
 font_families = [family.get_name() for family in font_map.list_families()]
 if "CC Icons" not in font_families:
     raise Exception(
@@ -139,10 +142,10 @@ script_dir = os.path.dirname(__file__)
 basedir = os.path.realpath(
     os.path.abspath(os.path.join(script_dir, "..", "www", "i"))
 )
-print "# basedir:", basedir
+print("# basedir:", basedir)
 
-for suite, licenses in SUITES.iteritems():
-    for lic, module_chars in licenses.iteritems():
+for suite, licenses in SUITES.items():
+    for lic, module_chars in licenses.items():
         for chars in module_chars:
             for dimensions in DIMENSIONS:
                 for background in BACKGROUNDS:

--- a/scripts/genicons.py
+++ b/scripts/genicons.py
@@ -82,9 +82,8 @@ def show_chars(ctx, chars, foreground, padding, width, height):
 
 def create_context(width, height):
     surface = cairo.ImageSurface(cairo.FORMAT_ARGB32, width, height)
-    context = cairo.Context(surface)
-    # ctx = pangocairo.CairoContext(context)
-    return context
+    ctx = cairo.Context(surface)
+    return ctx
 
 
 def set_background(ctx, background, width, height):


### PR DESCRIPTION
Fixes #9 

## Description
- PyGTK has been deprecated in favor of PyGI+GTK. So python3gi has been imported to work with pangocairo.
- cairo_font_map_get_default()''' as '''font_map_get_default()''' to get the default font map to use with Cairo. https://lazka.github.io/pgi-docs/PangoCairo-1.0/classes/FontMap.html#PangoCairo.FontMap
- New syntax of print statement and '''items()''' instead of '''iteritems''' (the python2 stuff!) 

## Other information
CairoContext attribute is not present in gi.repository.PangoCairo, hence the line was commented and the script appears to work. I would to like to know more about this.

## Checklist
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [ ] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

<!-- Make sure you read and understand the following attestation. -->
## Developer Certificate of Origin
```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```
